### PR TITLE
Adjust log messages upon home directory deploy

### DIFF
--- a/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
+++ b/api/src/main/java/edu/cornell/mannlib/vitro/webapp/application/VitroHomeDirectory.java
@@ -101,7 +101,7 @@ public class VitroHomeDirectory {
 	 * @return digest of each files checksum
 	 */
 	private Map<String, String> untar(File destination) {
-		log.info("Populating VIVO home at: " + destination.getPath());
+		log.info("Syncing VIVO home at: " + destination.getPath());
 
 		Map<String, String> digest = new HashMap<>();
 		Map<String, String> storedDigest = loadDigest();
@@ -135,7 +135,7 @@ public class VitroHomeDirectory {
 					// check to determine if it has changed
 					if (outFile.exists() && storedDigest.containsKey(outFilename)) {
 						String existingFileChecksum = checksum(outFile);
-						// if file has not changed and is not the same as new file, overwrite
+						// if file has not changed in home and is not the same as new file, overwrite
 						write = storedDigest.get(outFilename).equals(existingFileChecksum)
 							&& !existingFileChecksum.equals(newFileChecksum);
 					}
@@ -147,9 +147,11 @@ public class VitroHomeDirectory {
 							FileOutputStream fos = new FileOutputStream(outFile);
 						) {
 							IOUtils.copy(is, fos);
+							log.info(outFile.getAbsolutePath() + " source has changed and has not been "
+							         + "edited in home, updated file has been copied to home directory.");
 						}
 					} else {
-						log.info(outFile.getAbsolutePath() + " changes have been preserved.");
+						log.debug(outFile.getAbsolutePath() + " has been preserved.");
 					}
 				}
 			}


### PR DESCRIPTION
Edit log messages so the action being taken is a little more clear.

It doesn't seem necessary to broadcast all the non-changes to the log by default. This will appear in the log on each startup:
![Screen Shot 2021-02-04 at 9 34 27 AM](https://user-images.githubusercontent.com/10748475/106924397-43b18100-66cc-11eb-9e49-a06af8caad88.png)

After proposed changes, resulting log if one file is altered in source is: 
![Screen Shot 2021-02-04 at 9 30 57 AM](https://user-images.githubusercontent.com/10748475/106923830-b4a46900-66cb-11eb-9546-4c32e2a49ab7.png)
